### PR TITLE
Added german umlauts (äöü) so they wont be replaced by _

### DIFF
--- a/ing-postbox-download-all.js
+++ b/ing-postbox-download-all.js
@@ -96,7 +96,7 @@
             .map(function() {
               const nameSegments = $(this).find('> span.ibbr-table-cell:not(:last)')
                 .map(function() {
-                  return $(this).text().trim().replace(/[^A-Za-z0-9]/g, '_').replace('/\n/g', '');
+                  return $(this).text().trim().replace(/[^A-Za-z0-9ÄÖÜäöüß]/g, '_').replace('/\n/g', '');
                 })
                 .get();
 


### PR DESCRIPTION
Previously, german umaluts (üäöÜÄÖß) have been replaced by the regex in the filename.
They now have been added, so they will stay in the filename.

See Issue #8 