### PR TITLE
Match postbox page URLs with parameters

### DIFF
--- a/ing-postbox-download-all.js
+++ b/ing-postbox-download-all.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name        Download documents from postbox - ing.de
 // @namespace   https://github.com/ja-ka/violentmonkey
-// @match       https://banking.ing.de/app/postbox/postbox
-// @match       https://banking.ing.de/app/postbox/postbox_archiv
+// @match       https://banking.ing.de/app/postbox/postbox*
+// @match       https://banking.ing.de/app/postbox/postbox_archiv*
 // @grant       GM_download
 // @grant       GM_getValue
 // @grant       GM_setValue

--- a/ing-postbox-download-all.js
+++ b/ing-postbox-download-all.js
@@ -8,7 +8,7 @@
 // @grant       GM_setValue
 // @require     https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js
 // @require     https://cdn.jsdelivr.net/combine/npm/@violentmonkey/dom@1,npm/@violentmonkey/ui@0.5
-// @version     1.5
+// @version     1.6
 // @author      Jascha Kanngießer
 // @description Places a button "Alle herunterladen" next to "Alle archivieren" and downloads all documents visible on the page.
 // @icon        https://www.ing.de/favicon-32x32.png


### PR DESCRIPTION
Either ING made a change to the page URL format in general, or this happens in some cases only - in either case, matching everything after the `/postbox` allows for the script to work in more cases.